### PR TITLE
Minor fixes for the Maps docker file

### DIFF
--- a/docker/authserver/Dockerfile
+++ b/docker/authserver/Dockerfile
@@ -8,12 +8,13 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
     apt-get -qq -o Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    libboost-filesystem \
-    libboost-iostreams \
-    libboost-program-options \
-    libboost-system \
-    libboost-thread \
-    libssl1.0.0 \
+    libboost-filesystem1.62.0 \
+    libboost-iostreams1.62.0 \
+    libboost-program-options1.62.0 \
+    libboost-system1.62.0 \
+    libboost-thread1.62.0 \
+    libboost-regex1.62.0 \
+    libssl1.1 \
     libmariadbclient18 \
     netcat \
  < /dev/null > /dev/null \

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -19,12 +19,13 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
     bc \
     #blip \
     curl \
-    libboost-filesystem \
-    libboost-iostreams \
-    libboost-program-options \
-    libboost-system \
-    libboost-thread \
-    libssl1.0.0 \
+    libboost-filesystem1.62.0 \
+    libboost-iostreams1.62.0 \
+    libboost-program-options1.62.0 \
+    libboost-system1.62.0 \
+    libboost-thread1.62.0 \
+    libboost-regex1.62.0 \
+    libssl1.1 \
     libmariadbclient18 \
  < /dev/null > /dev/null \
  && rm -rf /var/lib/apt/lists/*

--- a/docker/worldserver/Dockerfile
+++ b/docker/worldserver/Dockerfile
@@ -9,12 +9,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
     apt-get -qq -o Dpkg::Use-Pty=0 install -y --no-install-recommends \
     curl \
-    libboost-filesystem \
-    libboost-iostreams \
-    libboost-program-options \
-    libboost-system \
-    libboost-thread \
-    libssl1.0.0 \
+    libboost-filesystem1.62.0 \
+    libboost-iostreams1.62.0 \
+    libboost-program-options1.62.0 \
+    libboost-system1.62.0 \
+    libboost-thread1.62.0 \
+    libboost-regex1.62.0 \
+    libssl1.1 \
     libmariadbclient18 \
     mariadb-client \
     netcat \


### PR DESCRIPTION
Minor fixes to make the docker file build.
- Added version tagging to 1.62.0 for `libboost` dependancies
- Added `libboost-regex`