### PR TITLE
fixed authserver and worldserver startup

### DIFF
--- a/docker/authserver/Dockerfile
+++ b/docker/authserver/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
     libboost-system1.62.0 \
     libboost-thread1.62.0 \
     libboost-regex1.62.0 \
-    libssl1.1 \
+    libssl1.0.2 \
     libmariadbclient18 \
     netcat \
  < /dev/null > /dev/null \

--- a/docker/worldserver/Dockerfile
+++ b/docker/worldserver/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
     libboost-regex1.62.0 \
     libssl1.1 \
     libmariadbclient18 \
+    libreadline7 \
     mariadb-client \
     netcat \
     xml2 \


### PR DESCRIPTION
worldserver was missing libreadline7
authserver was calling libssl1.0.2 but got libssl1.1

	changed:       docker/authserver/Dockerfile
	changed:       docker/worldserver/Dockerfile