### PR TITLE
fixed the download link for blip in the docker build files

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
  < /dev/null > /dev/null \
  && rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/neechbear/blip/releases/download/v0.10-1/blip_0.10-1_all.deb /tmp/blip.deb
+ADD https://github.com/neechbear/blip/releases/download/v0.10/blip_0.10-1_all.deb /tmp/blip.deb
 RUN dpkg -i /tmp/blip.deb && rm -f /tmp/blip.deb
 
 WORKDIR /

--- a/docker/mpqextractor/Dockerfile
+++ b/docker/mpqextractor/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
  < /dev/null > /dev/null \
  && rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/neechbear/blip/releases/download/v0.10-1/blip_0.10-1_all.deb /tmp/blip.deb
+ADD https://github.com/neechbear/blip/releases/download/v0.10/blip_0.10-1_all.deb /tmp/blip.deb
 RUN dpkg -i /tmp/blip.deb && rm -f /tmp/blip.deb
 
 WORKDIR /

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get -qq -o Dpkg::Use-Pty=0 update && \
  < /dev/null > /dev/null \
  && rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/neechbear/blip/releases/download/v0.10-1/blip_0.10-1_all.deb /tmp/blip.deb
+ADD https://github.com/neechbear/blip/releases/download/v0.10/blip_0.10-1_all.deb /tmp/blip.deb
 RUN dpkg -i /tmp/blip.deb && rm -f /tmp/blip.deb
 
 ENV install_prefix /opt/trinitycore


### PR DESCRIPTION
See issue https://github.com/neechbear/trinitycore/issues/10

I didn't realize another PR was in, oh well. Other PR had some whitespace, feel free to take whichever you prefer.